### PR TITLE
fix dark mode toggle in mobile header

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -29,11 +29,12 @@
             {%- endif -%}
           {%- endfor -%}
         </div>
+
+        <button id="theme-toggle" class="theme-toggle" aria-label="Toggle dark mode" title="Toggle dark mode">
+          <i class="fas fa-moon"></i>
+        </button>
       </nav>
     {%- endif -%}
-    <button id="theme-toggle" class="theme-toggle" aria-label="Toggle dark mode" title="Toggle dark mode">
-      <i class="fas fa-moon"></i>
-    </button>
     <script>
     (function(){
       var btn=document.getElementById('theme-toggle');

--- a/_sass/basil.scss
+++ b/_sass/basil.scss
@@ -460,6 +460,10 @@ pre, code {
     line-height: 1;
   }
 
+  .nav-trigger:checked ~ .theme-toggle {
+    display: none;
+  }
+
   :root[data-theme="dark"] .site-nav {
     background-color: var(--bg-secondary);
     border-color: var(--border-color);

--- a/_sass/basil.scss
+++ b/_sass/basil.scss
@@ -420,10 +420,8 @@ pre, code {
 }
 
 .theme-toggle {
-  position: absolute;
-  right: 1em;
-  top: 50%;
-  transform: translateY(-50%);
+  display: inline-block;
+  vertical-align: middle;
   background: none;
   border: 1px solid rgba(255, 255, 255, 0.3);
   border-radius: 4px;
@@ -432,10 +430,46 @@ pre, code {
   font-size: 1.2em;
   padding: 0.3em 0.5em;
   line-height: 1;
-  z-index: 10;
+  margin-left: 10px;
 
   &:hover {
     border-color: rgba(255, 255, 255, 0.6);
     color: #fff;
+  }
+}
+
+// Improve the mobile experience
+@media screen and (min-width: 601px) {
+  .site-nav .trigger {
+    display: inline;
+  }
+}
+
+@media screen and (max-width: 600px) {
+  .theme-toggle {
+    position: absolute;
+    top: 0;
+    right: 42px; // 36px hamburger + 6px gap
+    width: 36px;
+    height: 36px;
+    padding: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    margin-left: 0;
+    line-height: 1;
+  }
+
+  :root[data-theme="dark"] .site-nav {
+    background-color: var(--bg-secondary);
+    border-color: var(--border-color);
+  }
+
+  :root[data-theme="dark"] .site-nav .menu-icon svg {
+    fill: var(--text-primary);
+  }
+
+  :root[data-theme="dark"] .site-nav .trigger .page-link {
+    color: var(--text-primary);
   }
 }


### PR DESCRIPTION
Fix the toggle on mobile by moving it into the nav menu. Adjusted the hamburger menu color in dark mode. 

Before

<img width="1284" height="971" alt="image" src="https://github.com/user-attachments/assets/0d1ea0fe-03b7-4f36-8a1b-0b661347e63d" />

After 

<img width="508" height="342" alt="image" src="https://github.com/user-attachments/assets/1a51be5b-2c46-426e-acc6-933734001737" />
